### PR TITLE
Support links to section with parens in the title

### DIFF
--- a/src/DataSource/MarkdownElmUi.elm
+++ b/src/DataSource/MarkdownElmUi.elm
@@ -211,6 +211,8 @@ prefixMarkdownTableOfContents s =
 
                             ref =
                                 Theme.UI.stringToTitleId title
+                                    |> String.replace "(" "\\("
+                                    |> String.replace ")" "\\)"
                         in
                         depth ++ "- [" ++ title ++ "](#" ++ ref ++ ")"
                     )


### PR DESCRIPTION
Fix a broken link in the table of contents for https://elmcraft.org/faqs/html-lazy-not-working/

![image](https://github.com/elmcraft/elmcraft.org/assets/3869412/8b5e3fe9-1d18-4e18-a525-f571e79da446)


This is now fixed, but it looks a bit odd.

![image](https://github.com/elmcraft/elmcraft.org/assets/3869412/cf96b9ec-7807-44a3-b050-4265f07f9236)

I'm really not sure how to fix this, so I'll leave it at that (anyone who knows better, go ahead...), since this is already an improvement.