### PR TITLE
fix: ryannhg/date-format -> ryan-haskell/date-format

### DIFF
--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -26,6 +26,8 @@ Looking to learn something more specific? Ask in one of the [Community forums](/
 
 - [Beginning Elm](https://elmprogramming.com/) - Pawan Poudel
 
+- [Welcome to Elm!](https://www.youtube.com/playlist?list=PLuGpJqnV9DXq_ItwwUoJOGk_uCr72Yvzb) - Ryan Haskell
+
 #### Paid Online Courses
 
 - [Introduction to Elm, v2](https://frontendmasters.com/courses/intro-elm/) - Richard Feldman - ([Frontend Masters](https://frontendmasters.com/) subscription)

--- a/elm.json
+++ b/elm.json
@@ -50,7 +50,7 @@
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-css": "18.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "ryannhg/date-format": "2.3.0",
+            "ryan-haskell/date-format": "1.0.0",
             "the-sett/elm-syntax-dsl": "6.0.2",
             "tripokey/elm-fuzzy": "5.2.1",
             "turboMaCk/non-empty-list-alias": "1.3.1",


### PR DESCRIPTION
Update `ryannhg/date-format` package to new version `ryan-haskell/date-format` due to it no longer being available.