### PR TITLE
Update link to elm greenwood

### DIFF
--- a/content/faqs/is-elm-dead.md
+++ b/content/faqs/is-elm-dead.md
@@ -40,7 +40,7 @@ Elm's core release cycle works in batches, so a lack of frequent updates is not 
 
 Elm has a lot of [packages](https://package.elm-lang.org/) with a strong community philosophy of deeply thought out APIs and great documentation.
 
-Check out a list of recent package updates at [https://elm-greenwood.com/](https://elm-greenwood.com/).
+Check out a list of recent package updates at [https://releases.elm.dmy.fr/](https://releases.elm.dmy.fr/).
 
 
 ## Elm Ecosystem


### PR DESCRIPTION
The old link https://elm-greenwood.com/ is no longer available, but it still exists at https://releases.elm.dmy.fr/