### PR TITLE
Add a few videos

### DIFF
--- a/src/DataStatic/Videos.elm
+++ b/src/DataStatic/Videos.elm
@@ -1257,6 +1257,14 @@ all_ =
       , year = "2019"
       }
     , { categories = [ ExperienceReport, Commercial ]
+      , description = "Do you ever get tired of writing unit tests for ridiculous edge cases? Are you stuck on an old AngularJS app and need to modernize it, unsure how to move forward? Are you an FP lover looking for something more cohesive than lodash/fp and Ramda? Do you have a need for high-reliability in your project’s domain? Maybe the barrage of JS frameworks & libraries, ES features, TypeScript features, and package security issues are wearing you down. Well, look no further! I will introduce you to Elm, a fun way to build reliable web apps. We will look at common issues with reliability in popular frameworks and explore some of the ways Elm prevents them. Along the way, we’ll see how Elm reduces JS fatigue and makes happier developers. At the end, I will show how you can easily introduce Elm into an existing Angular or React app."
+      , event = EventUnknown "Detroit Tech Watch 2019"
+      , name = "Make Reliable Web Apps Without JS Fatigue"
+      , speaker = "Jared M. Smith"
+      , url = "https://youtu.be/80g1SnnvU0Q?si=8dus57QG3YZnRvL9"
+      , year = "2019"
+      }
+    , { categories = [ ExperienceReport, Commercial ]
       , description = "The UI client of our ARIC Fraud Hub product is a 100k LOC Elm app. Over the last 18 months we ported it from Agnular 1 to Elm, and added many new features. On the way we learned a lot. We’ll present a summary of that story: How we chose and adopted Elm. How we made Elm and Angular play nice together during the migration. What we learned from using Elm with a team of ~6 engineers on a large complex project. And what we want in the future: from Elm and from ourselves."
       , event = Conf ElmEurope2018
       , name = "Lessons from 100k LOC elm at Futurespace"

--- a/src/DataStatic/Videos.elm
+++ b/src/DataStatic/Videos.elm
@@ -80,6 +80,30 @@ all_ =
       , url = "https://www.youtube.com/watch?v=cyC-iENMFrc"
       , year = "2024"
       }
+    , { categories = [ LiveStream, Learn, Project ]
+      , description = ""
+      , event = EventUnknown ""
+      , name = "learning elm, so I don't need to use javascript"
+      , speaker = "bashbunni"
+      , url = "https://www.youtube.com/live/RPona9LJYv4?si=I3n0p7Ug2EkZDsW_"
+      , year = "2024"
+      }
+    , { categories = [ LiveStream, Learn, Project ]
+      , description = ""
+      , event = EventUnknown ""
+      , name = "learning elm, so I can (eventually) build a blog without JavaScript"
+      , speaker = "bashbunni"
+      , url = "https://www.youtube.com/live/afA577RlvHI?si=UuUy3GHXumYpOgAU"
+      , year = "2024"
+      }
+    , { categories = [ LiveStream, Learn, Project ]
+      , description = ""
+      , event = EventUnknown ""
+      , name = "My (elm) website looks like a terminal | ep.1 home page"
+      , speaker = "bashbunni"
+      , url = "https://www.youtube.com/live/M8VCm_S9-uw?si=zHnq_YT2HguXE6-L"
+      , year = "2024"
+      }
     , { categories = [ ElmPhilosophy, Iconic ]
       , description = "In the mythology of open source, programming languages are created by people who seemingly have no direct economic function. They are just really good at compilers (somehow) and have a house to live in (somehow) and have a lifetime to devote to creating a useful programming language (somehow!)\nWe will examine specific organizations that create programming languages. Where do the salaries for compiler engineers come from? How does Go end up with 5 engineers and Dart end up with 30? Who signs off on these expenses and why? Does this put any boundaries on language design or development practices? And how do the economics work for people outside of the major tech corporations?\nMy goal is to give the talk I needed to hear 10 years ago when I was just starting on Elm. By clearly delineating the many variations of corporate funding and independent funding, I hope users will come away with a better foundation for evaluating and comparing programming languages."
       , event = EventUnknown "Strange Loop 2023"

--- a/src/DataStatic/Videos.elm
+++ b/src/DataStatic/Videos.elm
@@ -104,6 +104,14 @@ all_ =
       , url = "https://www.youtube.com/live/M8VCm_S9-uw?si=zHnq_YT2HguXE6-L"
       , year = "2024"
       }
+    , { categories = [ Short ]
+      , description = ""
+      , event = EventUnknown ""
+      , name = "why elm (cause you won't stop asking me)"
+      , speaker = "bashbunni"
+      , url = "https://youtube.com/shorts/skbkYwFMitc?si=QrGRF99EBARK0RTF"
+      , year = "2024"
+      }
     , { categories = [ ElmPhilosophy, Iconic ]
       , description = "In the mythology of open source, programming languages are created by people who seemingly have no direct economic function. They are just really good at compilers (somehow) and have a house to live in (somehow) and have a lifetime to devote to creating a useful programming language (somehow!)\nWe will examine specific organizations that create programming languages. Where do the salaries for compiler engineers come from? How does Go end up with 5 engineers and Dart end up with 30? Who signs off on these expenses and why? Does this put any boundaries on language design or development practices? And how do the economics work for people outside of the major tech corporations?\nMy goal is to give the talk I needed to hear 10 years ago when I was just starting on Elm. By clearly delineating the many variations of corporate funding and independent funding, I hope users will come away with a better foundation for evaluating and comparing programming languages."
       , event = EventUnknown "Strange Loop 2023"

--- a/src/DataStatic/Videos.elm
+++ b/src/DataStatic/Videos.elm
@@ -72,6 +72,14 @@ all_ =
       , url = "https://www.youtube.com/watch?v=0SUM4869ODc"
       , year = "2024"
       }
+    , { categories = [ ExperienceReport ]
+      , description = "A couple years back, frustrated with my limited but already painful experiences with React and Vue, I did what any sane developer would. After spending all of 20 minutes playing with in-browser tutorials, I opted to make Elm the main language for my next project. In this talk, I will reflect on my experience building and growing a 10k LOC Elm codebase. Most importantly, I hope to convince you that Elm is awesome and that frontend development needs not be the lawless, weakly typed wasteland it first appears to be."
+      , event = EventUnknown "London Scala User Group"
+      , name = "Lessons learnt from writing 10k LOC in Elm"
+      , speaker = "Sophie Collard"
+      , url = "https://www.youtube.com/watch?v=cyC-iENMFrc"
+      , year = "2024"
+      }
     , { categories = [ ElmPhilosophy, Iconic ]
       , description = "In the mythology of open source, programming languages are created by people who seemingly have no direct economic function. They are just really good at compilers (somehow) and have a house to live in (somehow) and have a lifetime to devote to creating a useful programming language (somehow!)\nWe will examine specific organizations that create programming languages. Where do the salaries for compiler engineers come from? How does Go end up with 5 engineers and Dart end up with 30? Who signs off on these expenses and why? Does this put any boundaries on language design or development practices? And how do the economics work for people outside of the major tech corporations?\nMy goal is to give the talk I needed to hear 10 years ago when I was just starting on Elm. By clearly delineating the many variations of corporate funding and independent funding, I hope users will come away with a better foundation for evaluating and comparing programming languages."
       , event = EventUnknown "Strange Loop 2023"

--- a/src/Theme/Videos.elm
+++ b/src/Theme/Videos.elm
@@ -202,6 +202,16 @@ videoThumbnail video =
             if String.contains "youtube.com/watch/" video.url then
                 video.url |> String.split "/watch/" |> List.reverse |> List.head |> Maybe.withDefault ""
 
+            else if String.contains "youtube.com/live/" video.url then
+                video.url
+                    |> String.split "/live/"
+                    |> List.reverse
+                    |> List.head
+                    |> Maybe.withDefault ""
+                    |> String.split "?si="
+                    |> List.head
+                    |> Maybe.withDefault ""
+
             else if String.contains "youtube.com" video.url then
                 video.url |> String.split "watch?v=" |> List.reverse |> List.head |> Maybe.withDefault ""
 
@@ -372,6 +382,9 @@ categoryToString c =
         Testing ->
             "Testing"
 
+        LiveStream ->
+            "Live Stream"
+
 
 categoryFromString s =
     case s of
@@ -483,6 +496,9 @@ categoryFromString s =
         "Testing" ->
             Testing
 
+        "Live Stream" ->
+            LiveStream
+
         _ ->
             Unknown s
 
@@ -592,6 +608,9 @@ categoryToBackground c =
             colourCategory8
 
         Commercial ->
+            colourCategory8
+
+        LiveStream ->
             colourCategory8
 
         Unknown s ->

--- a/src/Theme/Videos.elm
+++ b/src/Theme/Videos.elm
@@ -202,6 +202,16 @@ videoThumbnail video =
             if String.contains "youtube.com/watch/" video.url then
                 video.url |> String.split "/watch/" |> List.reverse |> List.head |> Maybe.withDefault ""
 
+            else if String.contains "youtube.com/shorts/" video.url then
+                video.url
+                    |> String.split "/shorts/"
+                    |> List.reverse
+                    |> List.head
+                    |> Maybe.withDefault ""
+                    |> String.split "?si="
+                    |> List.head
+                    |> Maybe.withDefault ""
+
             else if String.contains "youtube.com/live/" video.url then
                 video.url
                     |> String.split "/live/"
@@ -385,6 +395,9 @@ categoryToString c =
         LiveStream ->
             "Live Stream"
 
+        Short ->
+            "Short"
+
 
 categoryFromString s =
     case s of
@@ -499,6 +512,9 @@ categoryFromString s =
         "Live Stream" ->
             LiveStream
 
+        "Short" ->
+            Short
+
         _ ->
             Unknown s
 
@@ -611,6 +627,9 @@ categoryToBackground c =
             colourCategory8
 
         LiveStream ->
+            colourCategory8
+
+        Short ->
             colourCategory8
 
         Unknown s ->

--- a/src/Theme/Videos.elm
+++ b/src/Theme/Videos.elm
@@ -234,6 +234,9 @@ videoThumbnail video =
                     |> String.split "?list="
                     |> List.head
                     |> Maybe.withDefault ""
+                    |> String.split "?si="
+                    |> List.head
+                    |> Maybe.withDefault ""
 
             else
                 "unknown"

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -134,6 +134,7 @@ type Category
     | Product
     | Teaching
     | Testing
+    | LiveStream
 
 
 type Conference

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -135,6 +135,7 @@ type Category
     | Teaching
     | Testing
     | LiveStream
+    | Short
 
 
 type Conference


### PR DESCRIPTION
Add a few videos:

- Sophie Collard's experience report from Lambda Days 2024: ["Lessons learnt from writing 10k LOC in Elm"](https://www.youtube.com/watch?v=cyC-iENMFrc)
- bashbunni's live streams (not sure if that's an acceptable category): 
  - ["learning elm, so I don't need to use javascript"](https://www.youtube.com/live/RPona9LJYv4?si=I3n0p7Ug2EkZDsW_)
  - ["learning elm, so I can (eventually) build a blog without JavaScript"](https://www.youtube.com/live/afA577RlvHI?si=UuUy3GHXumYpOgAU)
  - ["My (elm) website looks like a terminal | ep.1 home page"](https://www.youtube.com/live/M8VCm_S9-uw?si=zHnq_YT2HguXE6-L)
- bashbunni's short ["why elm (cause you won't stop asking me)"](https://youtube.com/shorts/skbkYwFMitc?si=QrGRF99EBARK0RTF)
- My experience report from DTW 2019 ["Make Reliable Web Apps Without JS Fatigue"](https://youtu.be/80g1SnnvU0Q?si=74O7y6by38sdadXc)

In the process, I also add two (2) new video categories:
- LiveStream
- Short

I use color 8 (a light blue) for the new categories.
![image](https://github.com/user-attachments/assets/b78e7952-8b1d-4717-8764-0d700fcaca3e)

There's some additional parsing for the different link types, too.
