### PR TITLE
Add link to Html.Lazy deep dive article

### DIFF
--- a/content/faqs/html-lazy-not-working.md
+++ b/content/faqs/html-lazy-not-working.md
@@ -10,9 +10,11 @@ editors: "@jfmengels"
 
 <tldr>tl;dr: You're likely recreating the values or view function on each render.</tldr>
 
-The [Elm guide on Html.Lazy](https://guide.elm-lang.org/optimization/lazy.html) is the best place to start.
+The [Elm guide on `Html.Lazy`](https://guide.elm-lang.org/optimization/lazy.html) is the best place to start.
 
 Here are some additional gotcha's that are helped by examples.
+
+For a deep dive into how `Html.Lazy` works, you can read [the caching behind Elm's `Html.Lazy`](https://jfmengels.net/caching-behind-elm-lazy/).
 
 <toc></toc>
 


### PR DESCRIPTION
I wrote an article deep diving into how `Html.Lazy` works, which should be a good addition to the existing `Html.Lazy` article.